### PR TITLE
Fix FactionsUUID-related bank lookup lag

### DIFF
--- a/src/cc/javajobs/factionsbridge/bridge/impl/factionsuuid/FactionsUUIDFaction.java
+++ b/src/cc/javajobs/factionsbridge/bridge/impl/factionsuuid/FactionsUUIDFaction.java
@@ -219,12 +219,11 @@ public class FactionsUUIDFaction implements IFaction {
      *
      * @return in the form of Double.
      */
-    @SuppressWarnings("deprecation")
     @Override
     public double getBank() {
         try {
-            if (!Econ.hasAccount(f.getAccountId())) return 0.0;
-            return Econ.getBalance(f.getAccountId());
+            if (!Econ.hasAccount(f)) return 0.0;
+            return Econ.getBalance(f);
         } catch (Exception ex) {
             throw new BridgeMethodException(getClass(), "getBank()", "Economy Potentially Disabled.");
         }


### PR DESCRIPTION
This patch changes "factions top" plugin lookups on large servers from literally minutes to seconds.

The root of the problem is generating new OfflinePlayer each lookup, vs using a cached one with the non-deprecated method that takes the Faction directly.