### PR TITLE
Improve resiliency in FUUID support

### DIFF
--- a/FactionsBridge/pom.xml
+++ b/FactionsBridge/pom.xml
@@ -29,7 +29,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0-SNAPSHOT</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/Factions_FactionsUUID/src/main/java/factionsuuid/FactionsUUIDAPI.java
+++ b/Factions_FactionsUUID/src/main/java/factionsuuid/FactionsUUIDAPI.java
@@ -56,7 +56,8 @@ public class FactionsUUIDAPI implements FactionsAPI {
     @Nullable
     @Override
     public Faction getFaction(@NotNull String id) {
-        return new FactionsUUIDFaction(Factions.getInstance().getFactionById(id));
+        com.massivecraft.factions.Faction faction = Factions.getInstance().getFactionById(id);
+        return faction == null ? null : new FactionsUUIDFaction(faction);
     }
 
     /**
@@ -68,7 +69,8 @@ public class FactionsUUIDAPI implements FactionsAPI {
     @Nullable
     @Override
     public Faction getFactionByTag(@NotNull String tag) {
-        return new FactionsUUIDFaction(Factions.getInstance().getByTag(tag));
+        com.massivecraft.factions.Faction faction = Factions.getInstance().getByTag(tag);
+        return faction == null ? null : new FactionsUUIDFaction(faction);
     }
 
     /**
@@ -129,8 +131,7 @@ public class FactionsUUIDAPI implements FactionsAPI {
     @NotNull
     @Override
     public Faction createFaction(@NotNull String name) throws IllegalStateException {
-        Faction fac = getFactionByName(name);
-        if (fac != null && !fac.isServerFaction()) throw new IllegalStateException("Faction already exists.");
+        if (Factions.getInstance().getByTag(name) != null) throw new IllegalStateException("Faction already exists.");
         com.massivecraft.factions.Faction faction = Factions.getInstance().createFaction();
         faction.setTag(name);
         return new FactionsUUIDFaction(faction);
@@ -144,7 +145,9 @@ public class FactionsUUIDAPI implements FactionsAPI {
      */
     @Override
     public void deleteFaction(@NotNull Faction faction) throws IllegalStateException {
-        Factions.getInstance().removeFaction(faction.getId());
+        com.massivecraft.factions.Faction fac = Factions.getInstance().getFactionById(faction.getId());
+        if (fac == null) throw new IllegalStateException("Faction does not exist.");
+        Factions.getInstance().removeFaction(fac.getId());
     }
 
     /**

--- a/Factions_FactionsUUID/src/main/java/factionsuuid/events/FactionsUUIDListener.java
+++ b/Factions_FactionsUUID/src/main/java/factionsuuid/events/FactionsUUIDListener.java
@@ -2,17 +2,16 @@ package factionsuuid.events;
 
 import cc.javajobs.factionsbridge.FactionsBridge;
 import cc.javajobs.factionsbridge.bridge.events.*;
-import cc.javajobs.factionsbridge.bridge.infrastructure.struct.FactionsAPI;
 import com.massivecraft.factions.event.LandClaimEvent;
 import com.massivecraft.factions.event.LandUnclaimAllEvent;
 import com.massivecraft.factions.event.LandUnclaimEvent;
+import factionsuuid.FactionsUUIDClaim;
+import factionsuuid.FactionsUUIDFPlayer;
+import factionsuuid.FactionsUUIDFaction;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.Objects;
-import java.util.UUID;
 
 import static org.bukkit.Bukkit.getPluginManager;
 import static org.bukkit.Bukkit.getScheduler;
@@ -26,11 +25,6 @@ import static org.bukkit.Bukkit.getScheduler;
 public class FactionsUUIDListener implements Listener {
 
     /**
-     * Instance of the {@link FactionsAPI} created by FactionsBridge.
-     */
-    private final FactionsAPI api = FactionsBridge.getFactionsAPI();
-
-    /**
      * Listener for the {@link LandClaimEvent}.
      * <p>
      *     This listener calls the {@link FactionClaimEvent}.
@@ -41,9 +35,9 @@ public class FactionsUUIDListener implements Listener {
     @EventHandler
     public void onClaim(@NotNull LandClaimEvent event) {
         FactionClaimEvent bridgeEvent = new FactionClaimEvent(
-                api.getClaim(event.getLocation().getChunk()),
-                Objects.requireNonNull(api.getFaction(event.getFaction().getId())),
-                api.getFPlayer(UUID.fromString(event.getfPlayer().getId())),
+                new FactionsUUIDClaim(event.getLocation()),
+                new FactionsUUIDFaction(event.getFaction()),
+                new FactionsUUIDFPlayer(event.getfPlayer()),
                 event
         );
         getPluginManager().callEvent(bridgeEvent);
@@ -61,8 +55,8 @@ public class FactionsUUIDListener implements Listener {
     @EventHandler
     public void onJoin(@NotNull com.massivecraft.factions.event.FPlayerJoinEvent event) {
         FactionJoinEvent bridgeEvent = new FactionJoinEvent(
-                Objects.requireNonNull(api.getFaction(event.getFaction().getId())),
-                api.getFPlayer(UUID.fromString(event.getfPlayer().getId())),
+                new FactionsUUIDFaction(event.getFaction()),
+                new FactionsUUIDFPlayer(event.getfPlayer()),
                 event
         );
         getPluginManager().callEvent(bridgeEvent);
@@ -80,8 +74,8 @@ public class FactionsUUIDListener implements Listener {
     @EventHandler
     public void onLeave(@NotNull com.massivecraft.factions.event.FPlayerLeaveEvent event) {
         FactionLeaveEvent bridgeEvent = new FactionLeaveEvent(
-                Objects.requireNonNull(api.getFaction(event.getFaction().getId())),
-                api.getFPlayer(UUID.fromString(event.getfPlayer().getId())),
+                new FactionsUUIDFaction(event.getFaction()),
+                new FactionsUUIDFPlayer(event.getfPlayer()),
                 FactionLeaveEvent.LeaveReason.fromString(event.getReason().name()),
                 event
         );
@@ -100,8 +94,8 @@ public class FactionsUUIDListener implements Listener {
     @EventHandler
     public void onUnclaimAll(@NotNull LandUnclaimAllEvent event) {
         FactionUnclaimAllEvent bridgeEvent = new FactionUnclaimAllEvent(
-                Objects.requireNonNull(api.getFaction(event.getFaction().getId())),
-                api.getFPlayer(UUID.fromString(event.getfPlayer().getId())),
+                new FactionsUUIDFaction(event.getFaction()),
+                new FactionsUUIDFPlayer(event.getfPlayer()),
                 event
         );
         getPluginManager().callEvent(bridgeEvent);
@@ -119,9 +113,9 @@ public class FactionsUUIDListener implements Listener {
     @EventHandler
     public void onUnclaim(@NotNull LandUnclaimEvent event) {
         FactionUnclaimEvent bridgeEvent = new FactionUnclaimEvent(
-                api.getClaim(event.getLocation().getChunk()),
-                Objects.requireNonNull(api.getFaction(event.getFaction().getId())),
-                api.getFPlayer(UUID.fromString(event.getfPlayer().getId())),
+                new FactionsUUIDClaim(event.getLocation()),
+                new FactionsUUIDFaction(event.getFaction()),
+                new FactionsUUIDFPlayer(event.getfPlayer()),
                 event
         );
         getPluginManager().callEvent(bridgeEvent);
@@ -140,8 +134,8 @@ public class FactionsUUIDListener implements Listener {
     public void onFactionCreate(@NotNull com.massivecraft.factions.event.FactionCreateEvent event) {
         getScheduler().runTaskLater(FactionsBridge.get().getDevelopmentPlugin(), () -> {
             FactionCreateEvent bridgeEvent = new FactionCreateEvent(
-                    Objects.requireNonNull(api.getFaction(event.getFaction().getId())),
-                    api.getFPlayer(UUID.fromString(event.getFPlayer().getId())),
+                    new FactionsUUIDFaction(event.getFaction()),
+                    new FactionsUUIDFPlayer(event.getFPlayer()),
                     event
             );
             getPluginManager().callEvent(bridgeEvent);
@@ -160,8 +154,8 @@ public class FactionsUUIDListener implements Listener {
     @EventHandler
     public void onFactionDisband(@NotNull com.massivecraft.factions.event.FactionDisbandEvent event) {
         FactionDisbandEvent bridgeEvent = new FactionDisbandEvent(
-                api.getFPlayer(event.getPlayer()),
-                Objects.requireNonNull(api.getFaction(event.getFaction().getId())),
+                new FactionsUUIDFPlayer(event.getFPlayer()),
+                new FactionsUUIDFaction(event.getFaction()),
                 FactionDisbandEvent.DisbandReason.UNKNOWN,
                 event
         );
@@ -180,7 +174,7 @@ public class FactionsUUIDListener implements Listener {
     @EventHandler
     public void onRename(@NotNull com.massivecraft.factions.event.FactionRenameEvent event) {
         FactionRenameEvent bridgeEvent = new FactionRenameEvent(
-                Objects.requireNonNull(api.getFaction(event.getFaction().getId())),
+                new FactionsUUIDFaction(event.getFaction()),
                 event.getFactionTag(),
                 event
         );


### PR DESCRIPTION
Two commits: 

1. Updated the maven shade plugin from a snapshot version, so things actually compile these days.
2. Improved resiliency in the FUUID support. No longer tries to pass null to a nonnull constructor, instead returning null in nullable methods as appropriate. Also, saved some conversion by just directly creating factions/fplayer objects in the events.