### PR TITLE
Bundle of changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/target/
+*/target/
+FactionsBridgeAPI/src/main/java/cc/javajobs/factionsbridge/Version.java
+FactionsBridge/dependency-reduced-pom.xml
+/jars/

--- a/FactionsBridge/pom.xml
+++ b/FactionsBridge/pom.xml
@@ -29,7 +29,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0-SNAPSHOT</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/FactionsBridge/pom.xml
+++ b/FactionsBridge/pom.xml
@@ -39,6 +39,10 @@
                         <configuration>
                             <relocations>
                                 <relocation>
+                                    <pattern>factionsuuidv4</pattern>
+                                    <shadedPattern>${package.directory}.factionsuuidv4</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>factionsuuid</pattern>
                                     <shadedPattern>${package.directory}.factionsuuid</shadedPattern>
                                 </relocation>
@@ -166,7 +170,15 @@
             <scope>compile</scope>
         </dependency>
 
-        <!-- Factions UUID -->
+        <!-- FactionsUUID -->
+        <dependency>
+            <groupId>cc.javajobs.factionsbridge</groupId>
+            <artifactId>Factions_FactionsUUIDv4</artifactId>
+            <version>${bridge.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- FactionsUUID Legacy -->
         <dependency>
             <groupId>cc.javajobs.factionsbridge</groupId>
             <artifactId>Factions_FactionsUUID</artifactId>

--- a/FactionsBridge/src/main/resources/plugin.yml
+++ b/FactionsBridge/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: cc.javajobs.factionsbridge.BridgePlugin
 version: ${project.version}
 api-version: 1.13
 authors: [Callum, mbax, Driftay, CustomEnchants, Lèbànk, Thefluffypvper, Splodgebox]
-softdepend: [Factions, FactionsX, FactionsBlue, Kingdoms, LegacyFactions, MedievalFactions, UltimateFactions, Towny, ImprovedFactions]
+softdepend: [Factions, FactionsUUID, FactionsX, FactionsBlue, Kingdoms, LegacyFactions, MedievalFactions, UltimateFactions, Towny, ImprovedFactions]
 commands:
   factionsbridge:
     aliases: [fbridge, factionbridge, facbridge, bridgefactions]

--- a/FactionsBridgeAPI/src/main/java/cc/javajobs/factionsbridge/FactionsBridge.java
+++ b/FactionsBridgeAPI/src/main/java/cc/javajobs/factionsbridge/FactionsBridge.java
@@ -84,6 +84,7 @@ public class FactionsBridge implements Communicator {
             log(sb.toString());
         }
         warn("Plugin Count§7:\t\t§f" + pluginCount);
+        warn("FactionsUUID Found§7:\t\t§f" + (Bukkit.getPluginManager().getPlugin("FactionsUUID") != null));
         warn("Factions Found§7:\t\t§f" + (Bukkit.getPluginManager().getPlugin("Factions") != null));
         warn("FactionsBlue Found§7:\t§f" + (Bukkit.getPluginManager().getPlugin("FactionsBlue") != null));
         warn("FactionsX Found§7:\t§f" + (Bukkit.getPluginManager().getPlugin("FactionsX") != null));

--- a/FactionsBridgeAPI/src/main/java/cc/javajobs/factionsbridge/bridge/Provider.java
+++ b/FactionsBridgeAPI/src/main/java/cc/javajobs/factionsbridge/bridge/Provider.java
@@ -33,6 +33,11 @@ public enum Provider {
             "factionsblue.FactionsBlueAPI",
             new AuthorConfiguration("1.1.6 Stable", "NickD")
     ),
+    Factions_FactionsUUIDv4(
+            "FactionsUUID",
+            "factionsuuidv4.FactionsUUIDAPI",
+            new AuthorConfiguration("4", "Matt Baxter", "Olof Larsson", "Brett Flannigan", "Trent Hensler", "various other contributors over more than a dozen years")
+    ),
     Factions_FactionsUUID(
             "Factions",
             "factionsuuid.FactionsUUIDAPI",

--- a/Factions_FactionsUUID/pom.xml
+++ b/Factions_FactionsUUID/pom.xml
@@ -15,6 +15,13 @@
     <modelVersion>4.0.0</modelVersion>
     <version>${bridge.version}</version>
 
+    <repositories>
+        <repository>
+            <id>dependency-download-releases</id>
+            <url>https://ci.ender.zone/plugin/repository/everything/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
 
         <!-- FactionsBridge API -->
@@ -27,11 +34,9 @@
 
         <!-- Factions UUID -->
         <dependency>
-            <groupId>Factions</groupId>
-            <artifactId>FactionsUUID</artifactId>
-            <version>LATEST</version>
-            <scope>system</scope>
-            <systemPath>${factions.location}/FactionsUUID.jar</systemPath>
+            <groupId>com.massivecraft</groupId>
+            <artifactId>Factions</artifactId>
+            <version>1.6.9.5-U0.6.40</version>
         </dependency>
 
     </dependencies>

--- a/Factions_FactionsUUID/src/main/java/factionsuuid/FactionsUUIDAPI.java
+++ b/Factions_FactionsUUID/src/main/java/factionsuuid/FactionsUUIDAPI.java
@@ -56,7 +56,8 @@ public class FactionsUUIDAPI implements FactionsAPI {
     @Nullable
     @Override
     public Faction getFaction(@NotNull String id) {
-        return new FactionsUUIDFaction(Factions.getInstance().getFactionById(id));
+        com.massivecraft.factions.Faction faction = Factions.getInstance().getFactionById(id);
+        return faction == null ? null : new FactionsUUIDFaction(faction);
     }
 
     /**
@@ -68,7 +69,8 @@ public class FactionsUUIDAPI implements FactionsAPI {
     @Nullable
     @Override
     public Faction getFactionByTag(@NotNull String tag) {
-        return new FactionsUUIDFaction(Factions.getInstance().getByTag(tag));
+        com.massivecraft.factions.Faction faction = Factions.getInstance().getByTag(tag);
+        return faction == null ? null : new FactionsUUIDFaction(faction);
     }
 
     /**
@@ -129,8 +131,7 @@ public class FactionsUUIDAPI implements FactionsAPI {
     @NotNull
     @Override
     public Faction createFaction(@NotNull String name) throws IllegalStateException {
-        Faction fac = getFactionByName(name);
-        if (fac != null && !fac.isServerFaction()) throw new IllegalStateException("Faction already exists.");
+        if (Factions.getInstance().getByTag(name) != null) throw new IllegalStateException("Faction already exists.");
         com.massivecraft.factions.Faction faction = Factions.getInstance().createFaction();
         faction.setTag(name);
         return new FactionsUUIDFaction(faction);
@@ -144,7 +145,9 @@ public class FactionsUUIDAPI implements FactionsAPI {
      */
     @Override
     public void deleteFaction(@NotNull Faction faction) throws IllegalStateException {
-        Factions.getInstance().removeFaction(faction.getId());
+        com.massivecraft.factions.Faction fac = Factions.getInstance().getFactionById(faction.getId());
+        if (fac == null) throw new IllegalStateException("Faction does not exist.");
+        Factions.getInstance().removeFaction(fac.getId());
     }
 
     /**

--- a/Factions_FactionsUUID/src/main/java/factionsuuid/FactionsUUIDFPlayer.java
+++ b/Factions_FactionsUUID/src/main/java/factionsuuid/FactionsUUIDFPlayer.java
@@ -39,7 +39,7 @@ public class FactionsUUIDFPlayer extends AbstractFPlayer<FPlayer> {
     @NotNull
     @Override
     public UUID getUniqueId() {
-        return fPlayer.getOfflinePlayer().getUniqueId();
+        return UUID.fromString(fPlayer.getId());
     }
 
     /**

--- a/Factions_FactionsUUID/src/main/java/factionsuuid/events/FactionsUUIDListener.java
+++ b/Factions_FactionsUUID/src/main/java/factionsuuid/events/FactionsUUIDListener.java
@@ -2,17 +2,16 @@ package factionsuuid.events;
 
 import cc.javajobs.factionsbridge.FactionsBridge;
 import cc.javajobs.factionsbridge.bridge.events.*;
-import cc.javajobs.factionsbridge.bridge.infrastructure.struct.FactionsAPI;
 import com.massivecraft.factions.event.LandClaimEvent;
 import com.massivecraft.factions.event.LandUnclaimAllEvent;
 import com.massivecraft.factions.event.LandUnclaimEvent;
+import factionsuuid.FactionsUUIDClaim;
+import factionsuuid.FactionsUUIDFPlayer;
+import factionsuuid.FactionsUUIDFaction;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.Objects;
-import java.util.UUID;
 
 import static org.bukkit.Bukkit.getPluginManager;
 import static org.bukkit.Bukkit.getScheduler;
@@ -26,11 +25,6 @@ import static org.bukkit.Bukkit.getScheduler;
 public class FactionsUUIDListener implements Listener {
 
     /**
-     * Instance of the {@link FactionsAPI} created by FactionsBridge.
-     */
-    private final FactionsAPI api = FactionsBridge.getFactionsAPI();
-
-    /**
      * Listener for the {@link LandClaimEvent}.
      * <p>
      *     This listener calls the {@link FactionClaimEvent}.
@@ -41,9 +35,9 @@ public class FactionsUUIDListener implements Listener {
     @EventHandler
     public void onClaim(@NotNull LandClaimEvent event) {
         FactionClaimEvent bridgeEvent = new FactionClaimEvent(
-                api.getClaim(event.getLocation().getChunk()),
-                Objects.requireNonNull(api.getFaction(event.getFaction().getId())),
-                api.getFPlayer(UUID.fromString(event.getfPlayer().getId())),
+                new FactionsUUIDClaim(event.getLocation()),
+                new FactionsUUIDFaction(event.getFaction()),
+                new FactionsUUIDFPlayer(event.getfPlayer()),
                 event
         );
         getPluginManager().callEvent(bridgeEvent);
@@ -61,8 +55,8 @@ public class FactionsUUIDListener implements Listener {
     @EventHandler
     public void onJoin(@NotNull com.massivecraft.factions.event.FPlayerJoinEvent event) {
         FactionJoinEvent bridgeEvent = new FactionJoinEvent(
-                Objects.requireNonNull(api.getFaction(event.getFaction().getId())),
-                api.getFPlayer(UUID.fromString(event.getfPlayer().getId())),
+                new FactionsUUIDFaction(event.getFaction()),
+                new FactionsUUIDFPlayer(event.getfPlayer()),
                 event
         );
         getPluginManager().callEvent(bridgeEvent);
@@ -80,8 +74,8 @@ public class FactionsUUIDListener implements Listener {
     @EventHandler
     public void onLeave(@NotNull com.massivecraft.factions.event.FPlayerLeaveEvent event) {
         FactionLeaveEvent bridgeEvent = new FactionLeaveEvent(
-                Objects.requireNonNull(api.getFaction(event.getFaction().getId())),
-                api.getFPlayer(UUID.fromString(event.getfPlayer().getId())),
+                new FactionsUUIDFaction(event.getFaction()),
+                new FactionsUUIDFPlayer(event.getfPlayer()),
                 FactionLeaveEvent.LeaveReason.fromString(event.getReason().name()),
                 event
         );
@@ -100,8 +94,8 @@ public class FactionsUUIDListener implements Listener {
     @EventHandler
     public void onUnclaimAll(@NotNull LandUnclaimAllEvent event) {
         FactionUnclaimAllEvent bridgeEvent = new FactionUnclaimAllEvent(
-                Objects.requireNonNull(api.getFaction(event.getFaction().getId())),
-                api.getFPlayer(UUID.fromString(event.getfPlayer().getId())),
+                new FactionsUUIDFaction(event.getFaction()),
+                new FactionsUUIDFPlayer(event.getfPlayer()),
                 event
         );
         getPluginManager().callEvent(bridgeEvent);
@@ -119,9 +113,9 @@ public class FactionsUUIDListener implements Listener {
     @EventHandler
     public void onUnclaim(@NotNull LandUnclaimEvent event) {
         FactionUnclaimEvent bridgeEvent = new FactionUnclaimEvent(
-                api.getClaim(event.getLocation().getChunk()),
-                Objects.requireNonNull(api.getFaction(event.getFaction().getId())),
-                api.getFPlayer(UUID.fromString(event.getfPlayer().getId())),
+                new FactionsUUIDClaim(event.getLocation()),
+                new FactionsUUIDFaction(event.getFaction()),
+                new FactionsUUIDFPlayer(event.getfPlayer()),
                 event
         );
         getPluginManager().callEvent(bridgeEvent);
@@ -140,8 +134,8 @@ public class FactionsUUIDListener implements Listener {
     public void onFactionCreate(@NotNull com.massivecraft.factions.event.FactionCreateEvent event) {
         getScheduler().runTaskLater(FactionsBridge.get().getDevelopmentPlugin(), () -> {
             FactionCreateEvent bridgeEvent = new FactionCreateEvent(
-                    Objects.requireNonNull(api.getFaction(event.getFaction().getId())),
-                    api.getFPlayer(UUID.fromString(event.getFPlayer().getId())),
+                    new FactionsUUIDFaction(event.getFaction()),
+                    new FactionsUUIDFPlayer(event.getFPlayer()),
                     event
             );
             getPluginManager().callEvent(bridgeEvent);
@@ -160,8 +154,8 @@ public class FactionsUUIDListener implements Listener {
     @EventHandler
     public void onFactionDisband(@NotNull com.massivecraft.factions.event.FactionDisbandEvent event) {
         FactionDisbandEvent bridgeEvent = new FactionDisbandEvent(
-                api.getFPlayer(event.getPlayer()),
-                Objects.requireNonNull(api.getFaction(event.getFaction().getId())),
+                new FactionsUUIDFPlayer(event.getFPlayer()),
+                new FactionsUUIDFaction(event.getFaction()),
                 FactionDisbandEvent.DisbandReason.UNKNOWN,
                 event
         );
@@ -180,7 +174,7 @@ public class FactionsUUIDListener implements Listener {
     @EventHandler
     public void onRename(@NotNull com.massivecraft.factions.event.FactionRenameEvent event) {
         FactionRenameEvent bridgeEvent = new FactionRenameEvent(
-                Objects.requireNonNull(api.getFaction(event.getFaction().getId())),
+                new FactionsUUIDFaction(event.getFaction()),
                 event.getFactionTag(),
                 event
         );

--- a/Factions_FactionsUUIDv4/README.md
+++ b/Factions_FactionsUUIDv4/README.md
@@ -1,0 +1,4 @@
+# FactionsUUID
+
+## Where do I buy/get it?
+Purchase: https://www.spigotmc.org/resources/factionsuuid.1035/

--- a/Factions_FactionsUUIDv4/pom.xml
+++ b/Factions_FactionsUUIDv4/pom.xml
@@ -9,18 +9,11 @@
         <version>parent</version>
     </parent>
 
-    <name>FactionsUUID Implementation</name>
-    <artifactId>Factions_FactionsUUID</artifactId>
+    <name>FactionsUUIDv4 Implementation</name>
+    <artifactId>Factions_FactionsUUIDv4</artifactId>
     <packaging>jar</packaging>
     <modelVersion>4.0.0</modelVersion>
     <version>${bridge.version}</version>
-
-    <repositories>
-        <repository>
-            <id>dependency-download-releases</id>
-            <url>https://ci.ender.zone/plugin/repository/everything/</url>
-        </repository>
-    </repositories>
 
     <dependencies>
 
@@ -32,13 +25,34 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- FactionsUUID Legacy -->
+        <!-- FactionsUUID -->
         <dependency>
-            <groupId>com.massivecraft</groupId>
-            <artifactId>Factions</artifactId>
-            <version>1.6.9.5-U0.6.40</version>
+            <groupId>dev.kitteh</groupId>
+            <artifactId>factions</artifactId>
+            <version>4.0.0-beta.6</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-serializer-legacy</artifactId>
+            <version>4.23.0</version>
+            <scope>provided</scope>
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>21</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/Factions_FactionsUUIDv4/src/main/java/factionsuuidv4/FactionsUUIDAPI.java
+++ b/Factions_FactionsUUIDv4/src/main/java/factionsuuidv4/FactionsUUIDAPI.java
@@ -1,0 +1,172 @@
+package factionsuuidv4;
+
+import cc.javajobs.factionsbridge.FactionsBridge;
+import cc.javajobs.factionsbridge.bridge.infrastructure.struct.Claim;
+import cc.javajobs.factionsbridge.bridge.infrastructure.struct.FPlayer;
+import cc.javajobs.factionsbridge.bridge.infrastructure.struct.Faction;
+import cc.javajobs.factionsbridge.bridge.infrastructure.struct.FactionsAPI;
+import dev.kitteh.factions.FLocation;
+import dev.kitteh.factions.FPlayers;
+import dev.kitteh.factions.Factions;
+import factionsuuidv4.events.FactionsUUIDListener;
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * FactionsUUID implementation of {@link FactionsAPI}.
+ */
+public class FactionsUUIDAPI implements FactionsAPI {
+
+    /**
+     * Method to obtain all Factions.
+     *
+     * @return Factions in the form of a List.
+     */
+    @NotNull
+    @Override
+    public List<Faction> getFactions() {
+        return Factions.factions().all().stream().map(FactionsUUIDFaction::new)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Method to obtain a Claim by chunk.
+     *
+     * @param chunk of the claim.
+     * @return Claim implementation.
+     */
+    @NotNull
+    @Override
+    public Claim getClaim(@NotNull Chunk chunk) {
+        return new FactionsUUIDClaim(new FLocation(chunk));
+    }
+
+    /**
+     * Method to retrieve a Faction by id.
+     *
+     * @param id of the Faction
+     * @return Faction implementation.
+     */
+    @Nullable
+    @Override
+    public Faction getFaction(@NotNull String id) {
+        dev.kitteh.factions.Faction fac = getFactionInternalById(id);
+        return fac == null ? null : new FactionsUUIDFaction(fac);
+    }
+
+    /**
+     * Method to retrieve a Faction by Tag.
+     *
+     * @param tag of the Faction
+     * @return Faction implementation.
+     */
+    @Nullable
+    @Override
+    public Faction getFactionByTag(@NotNull String tag) {
+        dev.kitteh.factions.Faction fac = Factions.factions().get(tag);
+        return fac == null ? null : new FactionsUUIDFaction(fac);
+    }
+
+    /**
+     * Method to obtain the FPlayer by a Player.
+     * <p>
+     * Due to the SpigotAPI, OfflinePlayer == Player through implementation, so you can pass both here.
+     * </p>
+     *
+     * @param player to get the FPlayer equivalent for.
+     * @return FPlayer implementation.
+     */
+    @NotNull
+    @Override
+    public FPlayer getFPlayer(@NotNull OfflinePlayer player) {
+        return new FactionsUUIDFPlayer(FPlayers.fPlayers().get(player));
+    }
+
+    /**
+     * Method to obtain WarZone.
+     *
+     * @return {@link Faction}
+     */
+    @NotNull
+    @Override
+    public Faction getWarZone() {
+        return new FactionsUUIDFaction(Factions.factions().warZone());
+    }
+
+    /**
+     * Method to obtain SafeZone.
+     *
+     * @return {@link Faction}
+     */
+    @NotNull
+    @Override
+    public Faction getSafeZone() {
+        return new FactionsUUIDFaction(Factions.factions().safeZone());
+    }
+
+    /**
+     * Method to obtain the Wilderness.
+     *
+     * @return {@link Faction}
+     */
+    @NotNull
+    @Override
+    public Faction getWilderness() {
+        return new FactionsUUIDFaction(Factions.factions().wilderness());
+    }
+
+    /**
+     * Method to create a new Faction with the given name.
+     *
+     * @param name of the new Faction.
+     * @return IFaction implementation.
+     * @throws IllegalStateException if the Faction exists already.
+     */
+    @NotNull
+    @Override
+    public Faction createFaction(@NotNull String name) throws IllegalStateException {
+        if (Factions.factions().get(name) != null) throw new IllegalStateException("Faction already exists.");
+        return new FactionsUUIDFaction(Factions.factions().create(name));
+    }
+
+    /**
+     * Method to delete a Faction.
+     *
+     * @param faction to delete
+     * @throws IllegalStateException if the Faction doesn't exist.
+     */
+    @Override
+    public void deleteFaction(@NotNull Faction faction) throws IllegalStateException {
+        dev.kitteh.factions.Faction fac = getFactionInternalById(faction.getId());
+        if (fac == null) {
+            throw new IllegalStateException("Invalid faction id from FactionsBridge: '" + faction.getId() + "'.");
+        }
+        Factions.factions().remove(fac);
+    }
+
+    /**
+     * Method to register events and handle event pass-through for the Bridge.
+     */
+    @Override
+    public boolean register() {
+        Bukkit.getPluginManager().registerEvents(
+                new FactionsUUIDListener(),
+                FactionsBridge.get().getDevelopmentPlugin()
+        );
+        return true;
+    }
+
+    private @Nullable dev.kitteh.factions.Faction getFactionInternalById(String id) {
+        try {
+            return Factions.factions().get(Integer.parseInt(id));
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException("Invalid faction id '" + id + "'.");
+        }
+    }
+}

--- a/Factions_FactionsUUIDv4/src/main/java/factionsuuidv4/FactionsUUIDClaim.java
+++ b/Factions_FactionsUUIDv4/src/main/java/factionsuuidv4/FactionsUUIDClaim.java
@@ -1,0 +1,87 @@
+package factionsuuidv4;
+
+import cc.javajobs.factionsbridge.bridge.infrastructure.AbstractClaim;
+import cc.javajobs.factionsbridge.bridge.infrastructure.struct.Faction;
+import dev.kitteh.factions.FLocation;
+import org.bukkit.Chunk;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * FactionsUUID implementation of {@link cc.javajobs.factionsbridge.bridge.infrastructure.struct.Claim}.
+ * Object Target: {@link FLocation}.
+ */
+public class FactionsUUIDClaim extends AbstractClaim<FLocation> {
+
+    /**
+     * Constructor to create a FactionsUUIDClaim.
+     * <p>
+     * This class will be used to create each implementation of a 'Claim'.
+     * </p>
+     *
+     * @param claim object which will be bridged using the FactionsBridge.
+     */
+    public FactionsUUIDClaim(@NotNull FLocation claim) {
+        super(claim);
+    }
+
+    /**
+     * Method to obtain the Chunk related to the Claim.
+     *
+     * @return {@link Chunk} represented by the 'Claim'.
+     */
+    @NotNull
+    @Override
+    public Chunk getChunk() {
+        return claim.asChunk();
+    }
+
+    /**
+     * Method to obtain the 'x' coordinate of the Claim.
+     *
+     * @return integer position on the 'x' axis.
+     */
+    @Override
+    public int getX() {
+        return claim.x();
+    }
+
+    /**
+     * Method to obtain the 'z' coordinate of the Claim.
+     *
+     * @return integer position on the 'z' axis.
+     */
+    @Override
+    public int getZ() {
+        return claim.z();
+    }
+
+    /**
+     * Method to obtain the Faction related to the Claim.
+     * <p>
+     * If there is no Faction, this method will return {@code null}.
+     * </p>
+     *
+     * @return {@link Faction} or {@code null}.
+     */
+    @Nullable
+    @Override
+    public Faction getFaction() {
+        return new FactionsUUIDFaction(claim.faction());
+    }
+
+    /**
+     * Method to determine if the Claim has a Faction related to it.
+     * <p>
+     * If the claim is owned by 'Wilderness' or the equivalent Faction, this method will return {@code false}.
+     * </p>
+     *
+     * @return {@code true} if a Faction owns this land (not Wilderness)
+     * @see Faction#isWilderness()
+     */
+    @Override
+    public boolean isClaimed() {
+        return !claim.faction().isWilderness();
+    }
+
+}

--- a/Factions_FactionsUUIDv4/src/main/java/factionsuuidv4/FactionsUUIDFPlayer.java
+++ b/Factions_FactionsUUIDv4/src/main/java/factionsuuidv4/FactionsUUIDFPlayer.java
@@ -1,0 +1,169 @@
+package factionsuuidv4;
+
+import cc.javajobs.factionsbridge.bridge.infrastructure.AbstractFPlayer;
+import cc.javajobs.factionsbridge.bridge.infrastructure.struct.Faction;
+import cc.javajobs.factionsbridge.bridge.infrastructure.struct.Role;
+import dev.kitteh.factions.FPlayer;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * FactionsUUID implementation of {@link cc.javajobs.factionsbridge.bridge.infrastructure.struct.FPlayer}.
+ * Object Target: {@link FPlayer}.
+ */
+public class FactionsUUIDFPlayer extends AbstractFPlayer<FPlayer> {
+
+    /**
+     * Constructor to create a FactionsUUIDFPlayer.
+     * <p>
+     * This class will be used to create each implementation of an 'FPlayer'.
+     * </p>
+     *
+     * @param fPlayer object which will be bridged using the FactionsBridge.
+     */
+    public FactionsUUIDFPlayer(@NotNull FPlayer fPlayer) {
+        super(fPlayer);
+    }
+
+    /**
+     * Method to get the UUID of the FPlayer.
+     *
+     * @return {@link UUID} originated from Minecraft/Mojang.
+     */
+    @NotNull
+    @Override
+    public UUID getUniqueId() {
+        return fPlayer.uniqueId();
+    }
+
+    /**
+     * Method to get the Name of the FPlayer.
+     *
+     * @return name of the player.
+     */
+    @NotNull
+    @Override
+    public String getName() {
+        return fPlayer.name();
+    }
+
+    /**
+     * Method to get the {@link Faction} relative to the FPlayer.
+     * <p>
+     * This method can return null, please use {@link #hasFaction()} to ensure the safest practice.
+     * </p>
+     *
+     * @return {@link Faction} or {@code null}.
+     * @see #hasFaction()
+     */
+    @Nullable
+    @Override
+    public Faction getFaction() {
+        return new FactionsUUIDFaction(fPlayer.faction());
+    }
+
+    /**
+     * Method to determine if the FPlayer has a Faction
+     *
+     * @return {@code true} if they do.
+     * @see #getFaction()
+     */
+    @Override
+    public boolean hasFaction() {
+        return fPlayer.hasFaction();
+    }
+
+    /**
+     * Method to get the OfflinePlayer related to the FPlayer.
+     *
+     * @return {@link OfflinePlayer} from the Bukkit API.
+     */
+    @NotNull
+    @Override
+    public OfflinePlayer getOfflinePlayer() {
+        return fPlayer.asOfflinePlayer();
+    }
+
+    /**
+     * Method to get the Player related to the FPlayer.
+     * <p>
+     * Please use {@link #isOnline()} before relying on this method as it can return null if the player isn't online.
+     * </p>
+     *
+     * @return {@link Player} or {@code null}.
+     * @see #isOnline()
+     */
+    @Nullable
+    @Override
+    public Player getPlayer() {
+        return fPlayer.asPlayer();
+    }
+
+    /**
+     * Method to determine if the player is online or not.
+     *
+     * @return {@code true} if they are connected to the server.
+     */
+    @Override
+    public boolean isOnline() {
+        return fPlayer.isOnline();
+    }
+
+    /**
+     * Method to get the power of the FPlayer.
+     *
+     * @return power value.
+     */
+    @Override
+    public double getPower() {
+        return fPlayer.power();
+    }
+
+    /**
+     * Method to set the power of the FPlayer.
+     *
+     * @param power to set.
+     */
+    @Override
+    public void setPower(double power) {
+        fPlayer.power(power);
+    }
+
+    /**
+     * Method to obtain the title of the FPlayer.
+     *
+     * @return title or tag of the FPlayer.
+     */
+    @Nullable
+    @Override
+    public String getTitle() {
+        return fPlayer.titleLegacy();
+    }
+
+    /**
+     * Method to set the title of the FPlayer.
+     *
+     * @param title to set.
+     */
+    @Override
+    public void setTitle(@NotNull String title) {
+        fPlayer.title(LegacyComponentSerializer.legacySection().deserialize(title));
+    }
+
+    /**
+     * Method to get the Role of the FPlayer.
+     *
+     * @return {@link Role}
+     */
+    @NotNull
+    @Override
+    public Role getRole() {
+        return Role.getRole(fPlayer.role().name());
+    }
+
+}

--- a/Factions_FactionsUUIDv4/src/main/java/factionsuuidv4/FactionsUUIDFaction.java
+++ b/Factions_FactionsUUIDv4/src/main/java/factionsuuidv4/FactionsUUIDFaction.java
@@ -1,0 +1,364 @@
+package factionsuuidv4;
+
+import cc.javajobs.factionsbridge.bridge.infrastructure.AbstractFaction;
+import cc.javajobs.factionsbridge.bridge.infrastructure.struct.Claim;
+import cc.javajobs.factionsbridge.bridge.infrastructure.struct.FPlayer;
+import cc.javajobs.factionsbridge.bridge.infrastructure.struct.Relationship;
+import dev.kitteh.factions.Faction;
+import dev.kitteh.factions.FactionsPlugin;
+import dev.kitteh.factions.Participator;
+import dev.kitteh.factions.integration.Econ;
+import dev.kitteh.factions.util.LazyLocation;
+import org.bukkit.Location;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static cc.javajobs.factionsbridge.bridge.infrastructure.struct.Relationship.getRelationship;
+
+/**
+ * FactionsUUID implementation of {@link cc.javajobs.factionsbridge.bridge.infrastructure.struct.Faction}.
+ * Object Target: {@link Faction}.
+ */
+public class FactionsUUIDFaction extends AbstractFaction<Faction> {
+
+    /**
+     * Constructor to create a FactionsUUIDFaction.
+     * <p>
+     * This class will be used to create each implementation of a 'Faction'.
+     * </p>
+     *
+     * @param faction object which will be bridged using the FactionsBridge.
+     */
+    public FactionsUUIDFaction(@NotNull Faction faction) {
+        super(faction);
+    }
+
+    /**
+     * Method to get the Id of the Faction.
+     * <p>
+     * Almost all implementations use a String for Ids so I will enforce this to reduce variety.
+     * </p>
+     *
+     * @return Id of the Faction of type String.
+     */
+    @NotNull
+    @Override
+    public String getId() {
+        return String.valueOf(faction.id());
+    }
+
+    /**
+     * Method to obtain the Name or Tag of the Faction.
+     *
+     * @return Name or Tag of the Faction
+     * @see #getTag()
+     */
+    @NotNull
+    @Override
+    public String getName() {
+        return faction.tag();
+    }
+
+    /**
+     * Method to obtain the Leader of the Faction.
+     * <p>
+     * Due to the nature of some of the implementations I will support, this can be {@code null}.
+     * </p>
+     *
+     * @return {@link FPlayer} or {@code null}.
+     */
+    @Nullable
+    @Override
+    public FPlayer getLeader() {
+        dev.kitteh.factions.FPlayer admin = faction.admin();
+        return admin != null ? new FactionsUUIDFPlayer(admin) : null;
+    }
+
+    /**
+     * Method to get all of the Claims linked to the Faction.
+     *
+     * @return {@link List} of {@link Claim} related to the Faction.
+     */
+    @NotNull
+    @Override
+    public List<Claim> getAllClaims() {
+        return faction.claims().stream().map(FactionsUUIDClaim::new).collect(Collectors.toList());
+    }
+
+    /**
+     * Method to get all of the Members of a Faction.
+     *
+     * @return {@link List} of {@link FPlayer} related to the Faction.
+     */
+    @NotNull
+    @Override
+    public List<FPlayer> getMembers() {
+        return faction.members().stream().map(FactionsUUIDFPlayer::new).collect(Collectors.toList());
+    }
+
+    /**
+     * Method to set the home of the Faction.
+     *
+     * @param location to set as the home location.
+     */
+    @Override
+    public void setHome(@NotNull Location location) {
+        faction.home(location);
+    }
+
+    /**
+     * Method to obtain the home of the Faction.
+     *
+     * @return {@link Location} of the home for the Faction.
+     */
+    @Nullable
+    @Override
+    public Location getHome() {
+        return faction.home();
+    }
+
+    /**
+     * Method to determine if the Faction is any form of Server-Faction.
+     * <p>
+     * A server faction is defined as a faction which is only for server operators to control the land-claiming and
+     * PVP'ing aspect of the game.
+     * <br>For example, FactionsUUID implements SafeZone, WarZone and Wilderness as Server-Factions.
+     * </p>
+     *
+     * @return {@code true} if the Faction is a Server-Faction
+     */
+    @Override
+    public boolean isServerFaction() {
+        return !faction.isNormal();
+    }
+
+    /**
+     * Method to determine if the Faction is Wilderness or not.
+     *
+     * @return {@code true} if the Faction is Wilderness (none).
+     */
+    @Override
+    public boolean isWilderness() {
+        return faction.isWilderness();
+    }
+
+    /**
+     * Method to determine if the Faction is WarZone or not.
+     *
+     * @return {@code true} if the Faction is WarZone.
+     */
+    @Override
+    public boolean isWarZone() {
+        return faction.isWarZone();
+    }
+
+    /**
+     * Method to determine if the Faction is SafeZone or not.
+     *
+     * @return {@code true} if the Faction is SafeZone (usually used for Spawnpoints).
+     */
+    @Override
+    public boolean isSafeZone() {
+        return faction.isSafeZone();
+    }
+
+    /**
+     * Method to determine if the Faction is in Peaceful mode.
+     *
+     * @return {@code true} if yes.
+     */
+    @Override
+    public boolean isPeaceful() {
+        return faction.isPeaceful();
+    }
+
+    /**
+     * Method to obtain the power of the Faction.
+     *
+     * @return the power of the Faction.
+     */
+    @Override
+    public double getPower() {
+        return faction.power();
+    }
+
+    /**
+     * Method to set the power of a Faction.
+     *
+     * @param power to set.
+     */
+    @Override
+    public void setPower(double power) {
+        if (bridge.catch_exceptions) return;
+        unsupported(getProvider(), "setPower(power)");
+    }
+
+    /**
+     * Method to get the points of the Faction.
+     *
+     * @return points of the Faction.
+     */
+    @Override
+    public int getPoints() {
+        if (bridge.catch_exceptions) return 0;
+        return (int) unsupported(getProvider(), "getPoints()");
+    }
+
+    /**
+     * Method to override the points of the Faction to the specified amount.
+     *
+     * @param points to set for the Faction.
+     * @see #getPoints()
+     */
+    @Override
+    public void setPoints(int points) {
+        if (bridge.catch_exceptions) return;
+        unsupported(getProvider(), "setPoints(int points)");
+    }
+
+    /**
+     * Method to obtain the Bank Balance of the Faction.
+     * <p>
+     * Credit goes to mbax for informing me of proper API usage.
+     * </p>
+     *
+     * @return bank balance in the form of {@link Double}.
+     */
+    @Override
+    public double getBank() {
+        if (!Econ.shouldBeUsed() || !FactionsPlugin.instance().conf().economy().isBankEnabled()) {
+            if (bridge.catch_exceptions) return 0.0D;
+            methodError(getClass(), "getBank()", "Economy hasn't been initialised or banks not enabled.");
+        }
+        return Econ.getBalance(faction);
+    }
+
+    /**
+     * Method to set the balance of the Faction.
+     *
+     * @param balance to set.
+     */
+    @Override
+    public void setBank(double balance) {
+        if (!Econ.shouldBeUsed() || !FactionsPlugin.instance().conf().economy().isBankEnabled()) {
+            if (bridge.catch_exceptions) return;
+            methodError(getClass(), "setBank(balance)", "Economy hasn't been initialised or banks not enabled.");
+        }
+        Econ.setBalance(faction, balance);
+    }
+
+    /**
+     * Method to get a Warp set by the faction by its name.
+     *
+     * @param name of the Warp to get
+     * @return {@link Location} related to that name, or {@code null}.
+     */
+    @Nullable
+    @Override
+    public Location getWarp(@NotNull String name) {
+        LazyLocation location = faction.warp(name);
+        return location == null ? null : location.asLocation();
+    }
+
+    /**
+     * Method to create a Warp manually.
+     *
+     * @param name     of the Warp to create.
+     * @param location of the warp.
+     */
+    @Override
+    public void createWarp(@NotNull String name, @NotNull Location location) {
+        faction.createWarp(name, new LazyLocation(location));
+    }
+
+    /**
+     * Method to get all of the Warps from the Faction.
+     * <p>
+     * The HashMap returned is of the form "String:Location".
+     * </p>
+     *
+     * @return {@link HashMap} where each entry is a 'warp'.
+     */
+    @NotNull
+    @Override
+    public HashMap<String, Location> getWarps() {
+        HashMap<String, Location> map = new HashMap<>();
+        for (String s : faction.warps().keySet()) {
+            Location loc = getWarp(s);
+            if (loc == null) continue;
+            map.put(s, loc);
+        }
+        return map;
+    }
+
+    /**
+     * Method to delete a warp by name.
+     *
+     * @param name of the warp to delete.
+     */
+    @Override
+    public void deleteWarp(@NotNull String name) {
+        faction.removeWarp(name);
+    }
+
+    /**
+     * Method to clear the Strikes related to the Faction
+     */
+    @Override
+    public void clearStrikes() {
+        if (bridge.catch_exceptions) return;
+        unsupported(getProvider(), "clearStrikes()");
+    }
+
+    /**
+     * Method to add a Strike to the Faction.
+     *
+     * @param sender who added the Strike
+     * @param reason for the Strike
+     */
+    @Override
+    public void addStrike(String sender, String reason) {
+        if (bridge.catch_exceptions) return;
+        unsupported(getProvider(), "addStrike(String sender, String reason)");
+    }
+
+    /**
+     * Method to remove a Strike from the Faction.
+     *
+     * @param sender who added the Strike
+     * @param reason for the Strike
+     */
+    @Override
+    public void removeStrike(String sender, String reason) {
+        if (bridge.catch_exceptions) return;
+        unsupported(getProvider(), "removeStrike(String sender, String reason)");
+    }
+
+    /**
+     * Method to obtain the total Strikes related to a Faction.
+     *
+     * @return total strikes.
+     */
+    @Override
+    public int getTotalStrikes() {
+        if (bridge.catch_exceptions) return 0;
+        return (int) unsupported(getProvider(), "getTotalStrikes()");
+    }
+
+    /**
+     * Method to obtain the Relationship between this Faction and another Faction.
+     *
+     * @param faction to get the relative relationship to this Faction.
+     * @return {@link Relationship} enumeration.
+     */
+    @NotNull
+    @Override
+    public Relationship getRelationshipTo(@NotNull AbstractFaction<?> faction) {
+        return getRelationship(this.faction.relationTo((Participator) faction.getFaction()).name());
+    }
+
+}

--- a/Factions_FactionsUUIDv4/src/main/java/factionsuuidv4/events/FactionsUUIDListener.java
+++ b/Factions_FactionsUUIDv4/src/main/java/factionsuuidv4/events/FactionsUUIDListener.java
@@ -1,0 +1,188 @@
+package factionsuuidv4.events;
+
+import cc.javajobs.factionsbridge.bridge.events.*;
+import dev.kitteh.factions.FPlayer;
+import dev.kitteh.factions.event.LandClaimEvent;
+import dev.kitteh.factions.event.LandUnclaimAllEvent;
+import dev.kitteh.factions.event.LandUnclaimEvent;
+import factionsuuidv4.FactionsUUIDClaim;
+import factionsuuidv4.FactionsUUIDFPlayer;
+import factionsuuidv4.FactionsUUIDFaction;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.jetbrains.annotations.NotNull;
+
+import static org.bukkit.Bukkit.getPluginManager;
+
+/**
+ * FactionsUUID implementation of the Bridges needed to handle all Custom Events.
+ *
+ * @author Callum Johnson
+ * @since 28/02/2021 - 09:02
+ */
+public class FactionsUUIDListener implements Listener {
+
+    /**
+     * Listener for the {@link LandClaimEvent}.
+     * <p>
+     *     This listener calls the {@link FactionClaimEvent}.
+     * </p>
+     *
+     * @param event to monitor.
+     */
+    @EventHandler
+    public void onClaim(@NotNull LandClaimEvent event) {
+        FactionClaimEvent bridgeEvent = new FactionClaimEvent(
+                new FactionsUUIDClaim(event.getLocation()),
+                new FactionsUUIDFaction(event.getFaction()),
+                new FactionsUUIDFPlayer(event.getFPlayer()),
+                event
+        );
+        getPluginManager().callEvent(bridgeEvent);
+        event.setCancelled(bridgeEvent.isCancelled());
+    }
+
+    /**
+     * Listener for the {@link dev.kitteh.factions.event.FPlayerJoinEvent}.
+     * <p>
+     *     This listener calls the {@link FactionJoinEvent}.
+     * </p>
+     *
+     * @param event to monitor.
+     */
+    @EventHandler
+    public void onJoin(@NotNull dev.kitteh.factions.event.FPlayerJoinEvent event) {
+        FactionJoinEvent bridgeEvent = new FactionJoinEvent(
+                new FactionsUUIDFaction(event.getFaction()),
+                new FactionsUUIDFPlayer(event.getFPlayer()),
+                event
+        );
+        getPluginManager().callEvent(bridgeEvent);
+        if (event.isCancellable()) {
+            event.setCancelled(bridgeEvent.isCancelled());
+        }
+    }
+
+    /**
+     * Listener for the {@link dev.kitteh.factions.event.FPlayerLeaveEvent}.
+     * <p>
+     *     This listener calls the {@link FactionLeaveEvent}.
+     * </p>
+     *
+     * @param event to monitor.
+     */
+    @EventHandler
+    public void onLeave(@NotNull dev.kitteh.factions.event.FPlayerLeaveEvent event) {
+        FactionLeaveEvent bridgeEvent = new FactionLeaveEvent(
+                new FactionsUUIDFaction(event.getFaction()),
+                new FactionsUUIDFPlayer(event.getFPlayer()),
+                FactionLeaveEvent.LeaveReason.fromString(event.getReason().name()),
+                event
+        );
+        getPluginManager().callEvent(bridgeEvent);
+        if (event.isCancellable()) {
+            event.setCancelled(bridgeEvent.isCancelled());
+        }
+    }
+
+    /**
+     * Listener for the {@link LandUnclaimAllEvent}.
+     * <p>
+     *     This listener calls the {@link FactionUnclaimAllEvent}.
+     * </p>
+     *
+     * @param event to monitor.
+     */
+    @EventHandler
+    public void onUnclaimAll(@NotNull LandUnclaimAllEvent event) {
+        FactionUnclaimAllEvent bridgeEvent = new FactionUnclaimAllEvent(
+                new FactionsUUIDFaction(event.getFaction()),
+                new FactionsUUIDFPlayer(event.getFPlayer()),
+                event
+        );
+        getPluginManager().callEvent(bridgeEvent);
+        event.setCancelled(bridgeEvent.isCancelled());
+    }
+
+    /**
+     * Listener for the {@link LandUnclaimEvent}.
+     * <p>
+     *     This listener calls the {@link FactionUnclaimEvent}.
+     * </p>
+     *
+     * @param event to monitor.
+     */
+    @EventHandler
+    public void onUnclaim(@NotNull LandUnclaimEvent event) {
+        FactionUnclaimEvent bridgeEvent = new FactionUnclaimEvent(
+                new FactionsUUIDClaim(event.getLocation()),
+                new FactionsUUIDFaction(event.getFaction()),
+                new FactionsUUIDFPlayer(event.getFPlayer()),
+                event
+        );
+        getPluginManager().callEvent(bridgeEvent);
+        event.setCancelled(bridgeEvent.isCancelled());
+    }
+
+    /**
+     * Listener for the {@link dev.kitteh.factions.event.FactionCreateEvent}.
+     * <p>
+     *     This listener calls the {@link FactionCreateEvent}.
+     * </p>
+     *
+     * @param event to monitor.
+     */
+    @EventHandler
+    public void onFactionCreate(@NotNull dev.kitteh.factions.event.FactionCreateEvent event) {
+        FPlayer fPlayer = event.getFPlayer();
+        if (fPlayer == null) { // Plugin-created, not fitting API spec for bridge event
+            return;
+        }
+        FactionCreateEvent bridgeEvent = new FactionCreateEvent(
+                new FactionsUUIDFaction(event.getFaction()),
+                new FactionsUUIDFPlayer(fPlayer),
+                event
+        );
+        getPluginManager().callEvent(bridgeEvent);
+    }
+
+    /**
+     * Listener for the {@link dev.kitteh.factions.event.FactionDisbandEvent}.
+     * <p>
+     *     This listener calls the {@link FactionDisbandEvent}.
+     * </p>
+     *
+     * @param event to monitor.
+     */
+    @EventHandler
+    public void onFactionDisband(@NotNull dev.kitteh.factions.event.FactionDisbandEvent event) {
+        FactionDisbandEvent bridgeEvent = new FactionDisbandEvent(
+                new FactionsUUIDFPlayer(event.getFPlayer()),
+                new FactionsUUIDFaction(event.getFaction()),
+                FactionDisbandEvent.DisbandReason.UNKNOWN,
+                event
+        );
+        getPluginManager().callEvent(bridgeEvent);
+        event.setCancelled(bridgeEvent.isCancelled());
+    }
+
+    /**
+     * Listener for the {@link dev.kitteh.factions.event.FactionRenameEvent}.
+     * <p>
+     *     This listener calls the {@link FactionRenameEvent}.
+     * </p>
+     *
+     * @param event to monitor.
+     */
+    @EventHandler
+    public void onRename(@NotNull dev.kitteh.factions.event.FactionRenameEvent event) {
+        FactionRenameEvent bridgeEvent = new FactionRenameEvent(
+                new FactionsUUIDFaction(event.getFaction()),
+                event.getFactionTag(),
+                event
+        );
+        getPluginManager().callEvent(bridgeEvent);
+        event.setCancelled(bridgeEvent.isCancelled());
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <module>Factions_AtlasFactions</module>
         <module>Factions_FactionsBlue</module>
         <module>Factions_FactionsUUID</module>
+        <module>Factions_FactionsUUIDv4</module>
         <module>Factions_FactionsX</module>
         <module>Factions_Kingdoms</module>
         <module>Factions_KingdomsV14</module>


### PR DESCRIPTION
* Upgraded maven shade plugin.
* Added a very basic .gitignore to filter stuff out.
* Improved FactionsUUID (legacy) support.
  * Pulls the 1.8-compatible jar (still compatible with the current latest).
  * Fixes potential error of putting a null faction in a wrapper when getting an invalid faction tag.
  * Removes potential issue of someone creating a faction named wilderness.
  * Properly throws expected IllegalStateException when trying to delete a nonexistent faction.
  * Saves a network call if using Spigot and getting a player's UUID.
  * Save several steps in FactionsAPI by not cycling between wrapper/non-wrapper just to end in a wrapper anyway.
* Adds FactionsUUID 4.0 support - the upcoming FactionsUUID release. It is finally a break away from shared plugin name and package, which means it breaks stuff and requires its own provider. 